### PR TITLE
Remove docker cache during build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
       }
       steps {
         script {
-          def dockerImage = docker.build 'linagora/esn-frontend-calendar'
+          def dockerImage = docker.build('linagora/esn-frontend-calendar', '--pull --no-cache .')
           docker.withRegistry('', 'dockerHub') {
             dockerImage.push('main')
           }
@@ -55,7 +55,7 @@ pipeline {
       }
       steps {
         script {
-          def dockerImage = docker.build 'linagora/esn-frontend-calendar'
+          def dockerImage = docker.build('linagora/esn-frontend-calendar', '--pull --no-cache .')
           docker.withRegistry('', 'dockerHub') {
             dockerImage.push(env.TAG_NAME)
           }


### PR DESCRIPTION
Needed, because docker will use cache, skipping the npm install step where the latest version of esn-frontend-common-libs is fetched