### PR TITLE
#594: Fix ICS TIMEZONE

### DIFF
--- a/src/esn.calendar.libs/app/app.module.js
+++ b/src/esn.calendar.libs/app/app.module.js
@@ -1,7 +1,6 @@
 'use strict';
 
 angular.module('esn.calendar.libs', [
-  'AngularJstz',
   'angularMoment',
   'esn.aggregator',
   'esn.authentication',
@@ -81,7 +80,6 @@ require('esn-frontend-common-libs/src/frontend/js/modules/localstorage.js');
 require('esn-frontend-common-libs/src/frontend/js/modules/datetime/datetime.module.js');
 require('esn-frontend-common-libs/src/frontend/js/modules/media-query.js');
 require('esn-frontend-common-libs/src/frontend/js/modules/escape-html.js');
-require('esn-frontend-common-libs/src/frontend/components/angular-jstz/angular-jstz.js');
 require('esn-frontend-common-libs/src/frontend/js/modules/websocket.js');
 require('esn-frontend-common-libs/src/frontend/js/modules/touchscreen-detector.js');
 require('esn-frontend-common-libs/src/frontend/js/modules/async-action.js');

--- a/src/esn.calendar.libs/app/components/event/form/open/open-event-from-search-form.service.spec.js
+++ b/src/esn.calendar.libs/app/components/event/form/open/open-event-from-search-form.service.spec.js
@@ -5,7 +5,7 @@
 var expect = chai.expect;
 
 describe('The calOpenEventFromSearchForm service', function() {
-  var $rootScope, $q, ICAL, calOpenEventFromSearchForm, calEventFormService, calendarAPI;
+  var $rootScope, $q, ICAL, calOpenEventFromSearchForm, calEventFormService, calendarAPI, esnDatetimeService;
   var publicNormalEvent, privateNormalEvent, recurrenceException, relatedEvents;
 
   beforeEach(function() {
@@ -47,11 +47,15 @@ describe('The calOpenEventFromSearchForm service', function() {
       $provide.value('calendarAPI', calendarAPI);
     });
 
-    inject(function(_$rootScope_, _$q_, _ICAL_, _calOpenEventFromSearchForm_) {
+    inject(function(_$rootScope_, _$q_, _ICAL_, _calOpenEventFromSearchForm_, _esnDatetimeService_) {
       ICAL = _ICAL_;
       $rootScope = _$rootScope_;
       $q = _$q_;
       calOpenEventFromSearchForm = _calOpenEventFromSearchForm_;
+      esnDatetimeService = _esnDatetimeService_;
+      esnDatetimeService.getTimeZone = function() {
+        return 'Europe/Paris';
+      };
     });
   });
 

--- a/src/esn.calendar.libs/app/components/partstat-buttons/partstat-buttons.controller.spec.js
+++ b/src/esn.calendar.libs/app/components/partstat-buttons/partstat-buttons.controller.spec.js
@@ -5,7 +5,7 @@
 const { expect } = chai;
 
 describe('The CalPartstatButtonsController', function() {
-  let $rootScope, $controller, $q, calEventService, session, CalendarShell, ICAL;
+  let $rootScope, $controller, $q, calEventService, session, CalendarShell, esnDatetimeService, ICAL;
   const shells = {};
   let fileSaveMock;
   let scope;
@@ -37,8 +37,7 @@ describe('The CalPartstatButtonsController', function() {
     });
   });
 
-  beforeEach(inject(function(_$rootScope_, _$controller_, _$q_, _CalendarShell_, _calEventService_, _session_,
-    _ICAL_) {
+  beforeEach(inject(function(_$rootScope_, _$controller_, _$q_, _CalendarShell_, _calEventService_, _session_, _esnDatetimeService_, _ICAL_) {
     $rootScope = _$rootScope_;
     $controller = _$controller_;
     $q = _$q_;
@@ -46,6 +45,10 @@ describe('The CalPartstatButtonsController', function() {
     calEventService = _calEventService_;
     session = _session_;
     ICAL = _ICAL_;
+    esnDatetimeService = _esnDatetimeService_;
+    esnDatetimeService.getTimeZone = function() {
+      return 'Europe/Paris';
+    };
   }));
 
   beforeEach(function() {

--- a/src/esn.calendar.libs/app/services/event-duplicate.service.spec.js
+++ b/src/esn.calendar.libs/app/services/event-duplicate.service.spec.js
@@ -6,7 +6,7 @@ const { expect } = chai;
 
 describe('the calEventDuplicateService service', () => {
   let $rootScope, calEventDuplicateService, CalendarShell, calMoment;
-  let VideoConfConfigurationServiceMock, uuid4Mock;
+  let VideoConfConfigurationServiceMock, uuid4Mock, esnDatetimeService;
 
   beforeEach(() => {
     VideoConfConfigurationServiceMock = {
@@ -27,11 +27,15 @@ describe('the calEventDuplicateService service', () => {
       $provide.value('uuid4', uuid4Mock);
     });
 
-    angular.mock.inject(function(_$rootScope_, _calEventDuplicateService_, _CalendarShell_, _calMoment_) {
+    angular.mock.inject(function(_$rootScope_, _calEventDuplicateService_, _CalendarShell_, _calMoment_, _esnDatetimeService_) {
       $rootScope = _$rootScope_;
       calEventDuplicateService = _calEventDuplicateService_;
       CalendarShell = _CalendarShell_;
       calMoment = _calMoment_;
+      esnDatetimeService = _esnDatetimeService_;
+      esnDatetimeService.getTimeZone = function() {
+        return 'Europe/Paris';
+      };
     });
   });
 

--- a/src/esn.calendar.libs/app/services/event-service.spec.js
+++ b/src/esn.calendar.libs/app/services/event-service.spec.js
@@ -63,16 +63,6 @@ describe('The calEventService service', function() {
       strongInfo: sinon.stub().returns({ close: self.closeNotificationMock })
     };
 
-    self.jstz = {
-      determine: function() {
-        return {
-          name: function() {
-            return 'Europe/Paris';
-          }
-        };
-      }
-    };
-
     self.calendarEventEmitterMock = {
       activitystream: {
         emitPostedMessage: sinon.spy()
@@ -98,7 +88,6 @@ describe('The calEventService service', function() {
 
     angular.mock.module(function($provide) {
       $provide.value('tokenAPI', self.tokenAPI);
-      $provide.value('jstz', self.jstz);
       $provide.value('uuid4', self.uuid4);
       $provide.value('notificationFactory', self.notificationFactoryMock);
       $provide.value('socket', self.socket);
@@ -144,7 +133,7 @@ describe('The calEventService service', function() {
     self.esnI18nService = esnI18nService;
     self.esnDatetimeService = esnDatetimeService;
     self.esnDatetimeService.getTimeZone = function() {
-      return 'Asia/Ho_Chi_Minh';
+      return 'Europe/Paris';
     };
 
     self.CAL_GRACE_DELAY_IS_ACTIVE_MOCK = true;
@@ -1298,8 +1287,8 @@ describe('The calEventService service', function() {
 
       vevent.addPropertyWithValue('uid', eventUUID);
       vevent.addPropertyWithValue('summary', 'test event');
-      vevent.addPropertyWithValue('dtstart', ICAL.Time.fromJSDate(self.calMoment().toDate())).setParameter('tzid', self.jstz.determine().name());
-      vevent.addPropertyWithValue('dtend', ICAL.Time.fromJSDate(self.calMoment().toDate())).setParameter('tzid', self.jstz.determine().name());
+      vevent.addPropertyWithValue('dtstart', ICAL.Time.fromJSDate(self.calMoment().toDate())).setParameter('tzid', self.esnDatetimeService.getTimeZone());
+      vevent.addPropertyWithValue('dtend', ICAL.Time.fromJSDate(self.calMoment().toDate())).setParameter('tzid', self.esnDatetimeService.getTimeZone());
       vevent.addPropertyWithValue('transp', 'OPAQUE');
       vevent.addPropertyWithValue('location', 'test location');
       vcalendar.addSubcomponent(vevent);

--- a/src/esn.calendar.libs/app/services/event-utils.spec.js
+++ b/src/esn.calendar.libs/app/services/event-utils.spec.js
@@ -63,7 +63,7 @@ describe('The calEventUtils service', function() {
     };
   });
 
-  beforeEach(inject(function(calEventUtils, $rootScope, calMoment, CalendarShell, session, CAL_MAX_DURATION_OF_SMALL_EVENT, CAL_EVENT_FORM, CAL_ICAL) {
+  beforeEach(inject(function(calEventUtils, $rootScope, calMoment, CalendarShell, esnDatetimeService, session, CAL_MAX_DURATION_OF_SMALL_EVENT, CAL_EVENT_FORM, CAL_ICAL) {
     this.calEventUtils = calEventUtils;
     this.$rootScope = $rootScope;
     this.calMoment = calMoment;
@@ -72,6 +72,11 @@ describe('The calEventUtils service', function() {
     this.CAL_MAX_DURATION_OF_SMALL_EVENT = CAL_MAX_DURATION_OF_SMALL_EVENT;
     this.CAL_EVENT_FORM = CAL_EVENT_FORM;
     this.CAL_ICAL = CAL_ICAL;
+    this.esnDatetimeService = esnDatetimeService;
+    this.esnDatetimeService.getTimeZone = function() {
+      return 'Europe/Paris';
+    };
+
     event.start = calMoment();
     event.end = event.start.add(this.CAL_MAX_DURATION_OF_SMALL_EVENT.DESKTOP, 'minutes');
   }));

--- a/src/esn.calendar.libs/app/services/fc-moment.spec.js
+++ b/src/esn.calendar.libs/app/services/fc-moment.spec.js
@@ -20,22 +20,11 @@ describe('calMoment factory', function() {
       }
     };
 
-    this.jstz = {
-      determine: function() {
-        return {
-          name: function() {
-            return 'Europe/Paris';
-          }
-        };
-      }
-    };
-
     var self = this;
 
     angular.mock.module('esn.calendar.libs');
     angular.mock.module(function($provide) {
       $provide.value('$window', self.window);
-      $provide.value('jstz', self.jstz);
       $provide.value('esnDatetimeService', self.esnDatetimeServiceMock);
     });
   });

--- a/src/esn.calendar.libs/app/services/master-event-cache.spec.js
+++ b/src/esn.calendar.libs/app/services/master-event-cache.spec.js
@@ -5,7 +5,7 @@
 var expect = chai.expect;
 
 describe('the calMasterEventCache service', function() {
-  var calMasterEventCache, CalendarShell, calMoment, timeoutMock, CAL_MASTER_EVENT_CACHE_TTL, path, shell, timeoutMockReturn;
+  var calMasterEventCache, CalendarShell, calMoment, esnDatetimeService, timeoutMock, CAL_MASTER_EVENT_CACHE_TTL, path, shell, timeoutMockReturn;
 
   beforeEach(function() {
     angular.mock.module('esn.calendar.libs');
@@ -18,11 +18,15 @@ describe('the calMasterEventCache service', function() {
     timeoutMock = sinon.stub().returns(timeoutMockReturn);
     timeoutMock.cancel = sinon.spy();
 
-    angular.mock.inject(function(_calMasterEventCache_, _CalendarShell_, _calMoment_, _CAL_MASTER_EVENT_CACHE_TTL_) {
+    angular.mock.inject(function(_calMasterEventCache_, _CalendarShell_, _calMoment_, _esnDatetimeService_, _CAL_MASTER_EVENT_CACHE_TTL_) {
       calMasterEventCache = _calMasterEventCache_;
       CalendarShell = _CalendarShell_;
       calMoment = _calMoment_;
       CAL_MASTER_EVENT_CACHE_TTL = _CAL_MASTER_EVENT_CACHE_TTL_;
+      esnDatetimeService = _esnDatetimeService_;
+      esnDatetimeService.getTimeZone = function() {
+        return 'Europe/Paris';
+      };
     });
 
     path = 'aPath';

--- a/src/esn.calendar.libs/app/services/shells/calendar-shell.js
+++ b/src/esn.calendar.libs/app/services/shells/calendar-shell.js
@@ -37,7 +37,6 @@ require('./valarm-shell.js');
   function CalendarShellFactory(
     $q,
     ICAL,
-    jstz,
     uuid4,
     calendarUtils,
     calEventAPI,
@@ -53,7 +52,7 @@ require('./valarm-shell.js');
     CAL_EVENT_CLASS,
     esnDatetimeService
   ) {
-    var localTimezone = jstz.determine().name();
+    var localTimezone;
 
     function CalendarShell(vcomponent, extendedProperties) {
       var vcalendar, vevent;
@@ -90,6 +89,7 @@ require('./valarm-shell.js');
           this.icalEvent.endDate.zone = this.timezones[this.icalEvent.endDate.timezone] || this.icalEvent.endDate.zone;
         }
       }
+      localTimezone = getUserTimeZone();
 
       var localTimezoneFound = _.contains(Object.keys(this.timezones), localTimezone);
 
@@ -935,7 +935,7 @@ require('./valarm-shell.js');
     }
 
     function getUserTimeZone() {
-      return esnDatetimeService.getTimeZone() || localTimezone;
+      return esnDatetimeService.getTimeZone();
     }
 
     function ensureAlarmCoherence() {

--- a/src/esn.calendar.libs/app/services/shells/calendar-shell.spec.js
+++ b/src/esn.calendar.libs/app/services/shells/calendar-shell.spec.js
@@ -47,12 +47,6 @@ describe('CalendarShell factory', function() {
     this.localTimezone = 'Asia/Ho_Chi_Minh';
     this.userTimezone = 'Asia/Ho_Chi_Minh';
 
-    this.jstzMock = {
-      determine: _.constant({
-        name: _.constant(this.localTimezone)
-      })
-    };
-
     var self = this;
 
     esnDatetimeService = {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,4 +1,3 @@
-window.jstz = require('esn-frontend-common-libs/src/frontend/components/jstzdetect/jstz.js');
 window.jQuery = require('jquery/dist/jquery.js');
 window.$ = window.jQuery;
 require('jquery-ui/ui/widgets/draggable.js');

--- a/src/linagora.esn.calendar/app/app.js
+++ b/src/linagora.esn.calendar/app/app.js
@@ -1,7 +1,6 @@
 'use strict';
 
 angular.module('esn.calendar', [
-  'AngularJstz',
   'angularMoment',
   'ct.ui.router.extras.dsr',
   'esn.mailto-handler',
@@ -92,7 +91,6 @@ require('esn-frontend-common-libs/src/frontend/js/modules/localstorage.js');
 require('esn-frontend-common-libs/src/frontend/js/modules/datetime/datetime.module.js');
 require('esn-frontend-common-libs/src/frontend/js/modules/media-query.js');
 require('esn-frontend-common-libs/src/frontend/js/modules/escape-html.js');
-require('esn-frontend-common-libs/src/frontend/components/angular-jstz/angular-jstz.js');
 require('esn-frontend-common-libs/src/frontend/js/modules/websocket.js');
 require('esn-frontend-common-libs/src/frontend/js/modules/touchscreen-detector.js');
 require('esn-frontend-common-libs/src/frontend/js/modules/async-action.js');

--- a/src/linagora.esn.calendar/app/components/event-alarm-consultation/event-alarm-consultation.controller.spec.js
+++ b/src/linagora.esn.calendar/app/components/event-alarm-consultation/event-alarm-consultation.controller.spec.js
@@ -5,14 +5,18 @@
 var expect = chai.expect;
 
 describe('The calEventAlarmConsultationController', function() {
-  var $controller, CalendarShell, moment;
+  var $controller, CalendarShell, moment, esnDatetimeService;
 
   beforeEach(function() {
     angular.mock.module('esn.calendar');
-    angular.mock.inject(function(_$controller_, _CalendarShell_, _moment_) {
+    angular.mock.inject(function(_$controller_, _CalendarShell_, _moment_, _esnDatetimeService_) {
       $controller = _$controller_;
       CalendarShell = _CalendarShell_;
       moment = _moment_;
+      esnDatetimeService = _esnDatetimeService_;
+      esnDatetimeService.getTimeZone = function() {
+        return 'Europe/Paris';
+      };
     });
   });
 

--- a/src/linagora.esn.calendar/app/components/event-date-consultation/event-date-consultation.controller.spec.js
+++ b/src/linagora.esn.calendar/app/components/event-date-consultation/event-date-consultation.controller.spec.js
@@ -5,15 +5,19 @@
 var expect = chai.expect;
 
 describe('The calEventDateConsultationController', function() {
-  var $controller, calMoment, CalendarShell;
+  var $controller, calMoment, CalendarShell, esnDatetimeService;
 
   beforeEach(function() {
     angular.mock.module('esn.calendar');
 
-    angular.mock.inject(function(_$controller_, _calMoment_, _CalendarShell_) {
+    angular.mock.inject(function(_$controller_, _calMoment_, _CalendarShell_, _esnDatetimeService_) {
       $controller = _$controller_;
       calMoment = _calMoment_;
       CalendarShell = _CalendarShell_;
+      esnDatetimeService = _esnDatetimeService_;
+      esnDatetimeService.getTimeZone = function() {
+        return 'Europe/Paris';
+      };
     });
   });
 

--- a/webpack.commons.js
+++ b/webpack.commons.js
@@ -163,18 +163,6 @@ module.exports = {
         }
       },
       /*
-      for angular-jstz in esn-frontend-common-libs
-      */
-      {
-        test: require.resolve(commonLibsPath + '/src/frontend/components/jstzdetect/jstz.js'),
-        loader: 'expose-loader',
-        options: {
-          exposes: [
-            'jstz'
-          ]
-        }
-      },
-      /*
         usefull, at least for esn-frontend-common-libs / notification.js:
 
         var notification = $window.$.notify(escapeHtmlFlatObject(options), angular.extend({}, getDefaultSettings(options), settings));


### PR DESCRIPTION
Fixes invalid ICS

TIMEZONE now matches DTSTART adn DTEND timezone

```
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//Sabre//Sabre VObject 4.1.3//EN
CALSCALE:GREGORIAN
METHOD:REQUEST
BEGIN:VTIMEZONE
TZID:Europe/Paris
BEGIN:DAYLIGHT
TZOFFSETFROM:+0100
TZOFFSETTO:+0200
TZNAME:CEST
DTSTART:19700329T020000
RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
END:DAYLIGHT
BEGIN:STANDARD
TZOFFSETFROM:+0200
TZOFFSETTO:+0100
TZNAME:CET
DTSTART:19701025T030000
RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
END:STANDARD
END:VTIMEZONE
BEGIN:VEVENT
UID:2493c80c-12bc-4662-ac7d-3512342bb80f
TRANSP:OPAQUE
DTSTART;TZID=Europe/Paris:20210710T133000
DTEND;TZID=Europe/Paris:20210710T150000
CLASS:PUBLIC
X-OPENPAAS-VIDEOCONFERENCE:
SUMMARY:
ORGANIZER;CN=user@open-paas.org:mailto:user@open-paas.org
ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVI
 DUAL:mailto:toto@toto
ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL:mailto:u
 ser@open-paas.org
DTSTAMP:20210706T162832Z
SEQUENCE:0
END:VEVENT
END:VCALENDAR
```
