### PR TITLE
#611 Fix event move

### DIFF
--- a/src/esn.calendar.libs/app/components/event/form/event-form.controller.js
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.controller.js
@@ -687,7 +687,11 @@ function CalEventFormController(
   }
 
   /**
-   * Checks if an event can be moved into another calendar
+   * Move event to another calendar if:
+   *
+   * * previous processes have succeeded
+   * * user can perform move
+   * * Event calendar have been modified
    *
    * @param {boolean} success - true if the previous response was successful
    *

--- a/src/esn.calendar.libs/app/components/event/form/event-form.controller.js
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.controller.js
@@ -379,7 +379,7 @@ function CalEventFormController(
 
     $scope.editedEvent.attendees = getUpdatedAttendees();
 
-    if (!calEventUtils.hasAnyChange($scope.editedEvent, $scope.event) && !_calendarHasChanged()) {
+    if (!calEventUtils.hasAnyChange($scope.editedEvent, $scope.event) && !_eventCalendarHasChanged()) {
       _hideModal();
 
       return;
@@ -417,7 +417,7 @@ function CalEventFormController(
           { graceperiod: true, notifyFullcalendar: $state.is('calendar.main') }
         );
       })
-      .then(canPerformCalendarMove)
+      .then(moveEventIfPossible)
       .then(onEventCreateUpdateResponse)
       .finally(function() {
         $scope.restActive = false;
@@ -696,14 +696,14 @@ function CalEventFormController(
    *
    * @returns {Promise}
    */
-  function canPerformCalendarMove(success) {
+  function moveEventIfPossible(success) {
     if (!success ||
       !$scope.canMoveEvent ||
-      !_calendarHasChanged()) {
+      !_eventCalendarHasChanged()) {
       return $q.when();
     }
 
-    return _calendarHasChanged() ? changeCalendar() : $q.when();
+    return moveEvent();
   }
 
   /**
@@ -711,7 +711,7 @@ function CalEventFormController(
    *
    * @returns {Promise} - resolves to true if the event calendar has changed
    */
-  function changeCalendar() {
+  function moveEvent() {
     const destinationPath = calPathBuilder.forEventId($scope.calendarHomeId, _getCalendarByUniqueId($scope.selectedCalendar.uniqueId).id, $scope.editedEvent.uid);
     const sourcePath = $scope.event.path;
 
@@ -723,7 +723,7 @@ function CalEventFormController(
    *
    * @returns {Boolean} - true if the event calendar and the selected calendar are different
    */
-  function _calendarHasChanged() {
+  function _eventCalendarHasChanged() {
     return _getCalendarByUniqueId($scope.selectedCalendar.uniqueId).id !== $scope.editedEvent.calendarId;
   }
 }

--- a/src/esn.calendar.libs/app/components/event/form/event-form.controller.spec.js
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.controller.spec.js
@@ -1297,6 +1297,29 @@ describe('The CalEventFormController controller', function() {
           expect(calOpenEventFormMock).to.have.been.calledWith(sinon.match.any, scope.editedEvent);
         });
 
+        it('should not attempt to move the event to another calendar if user is not allowed to move event', function() {
+          const fakeEvent = {
+            start: start,
+            end: end,
+            title: 'oldtitle',
+            path: '/calendars/owner/id.json',
+            etag: '123123'
+          };
+
+          scope.canMoveEvent = false;
+          scope.event = CalendarShell.fromIncompleteShell(fakeEvent);
+          initController();
+
+          scope.editedEvent = CalendarShell.fromIncompleteShell({ ...fakeEvent, title: 'new title', path: `/calendars/owner/id2/${scope.editedEvent.uid}.ics` });
+          scope.selectedCalendar.uniqueId = '/calendars/owner/id2.json';
+          scope.calendarHomeId = 'owner';
+
+          scope.modifyEvent();
+          scope.$digest();
+
+          expect(calEventServiceMock.moveEvent).to.have.not.been.called;
+        });
+
         it('should attempt to move the event to another calendar if the organizer changed it', function() {
           const fakeEvent = {
             start: start,
@@ -1306,6 +1329,7 @@ describe('The CalEventFormController controller', function() {
             etag: '123123'
           };
 
+          scope.canMoveEvent = true;
           scope.event = CalendarShell.fromIncompleteShell(fakeEvent);
           initController();
 
@@ -1331,6 +1355,7 @@ describe('The CalEventFormController controller', function() {
             etag: '123123'
           };
 
+          scope.canMoveEvent = true;
           scope.event = CalendarShell.fromIncompleteShell(fakeEvent);
           initController();
 

--- a/src/esn.calendar.libs/app/components/event/form/event-form.pug
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.pug
@@ -46,7 +46,7 @@ form.event-form(role="form", name="form", aria-hidden="true", ng-class="{ 'reado
                     i.mdi.mdi-calendar-multiple
                   .fg-line
                     md-input-container(ng-click="changeBackdropZIndex()")
-                      md-select(ng-disabled="!canModifyEvent", ng-model="selectedCalendar.uniqueId", md-container-class="cal-select-dropdown" aria-label="calendar")
+                      md-select(ng-disabled="!canMoveEvent", ng-model="selectedCalendar.uniqueId", md-container-class="cal-select-dropdown" aria-label="calendar")
                         md-option(ng-value="calendar.getUniqueId()" ng-repeat="calendar in calendars | filter: { readOnly: false }")
                           cal-select-calendar-item(calendar="calendar")
             cal-event-date-edition(event="editedEvent", disabled='!canModifyEvent', use-24hour-format='use24hourFormat', on-date-change='onDateChange')
@@ -167,7 +167,7 @@ form.event-form(role="form", name="form", aria-hidden="true", ng-class="{ 'reado
                 span {{ 'Duplicate this event' | translate }}
               i.mdi.mdi-library-plus
         .flex-vertical-centered.flex-end
-          button.btn.btn-link.color-default.close-button(type='button', ng-click="shouldShowMoreOptions = !shouldShowMoreOptions") 
+          button.btn.btn-link.color-default.close-button(type='button', ng-click="shouldShowMoreOptions = !shouldShowMoreOptions")
             i.mdi.mdi-chevron-down(ng-if="!shouldShowMoreOptions")
             span(ng-if="!shouldShowMoreOptions") {{ 'More options' | translate }}
             i.mdi.mdi-chevron-up(ng-if="shouldShowMoreOptions")

--- a/src/esn.calendar.libs/app/services/cal-ui-authorization-service.js
+++ b/src/esn.calendar.libs/app/services/cal-ui-authorization-service.js
@@ -22,6 +22,7 @@ function calUIAuthorizationService(
     canModifyEvent,
     canModifyEventRecurrence,
     canModifyPublicSelection,
+    canMoveEvent,
     canShowDelegationTab
   };
 
@@ -68,6 +69,10 @@ function calUIAuthorizationService(
     // the owner of a Subscription is not the same the current user, so we need to check for calendar.isSubscription()
     // to allow the user to unsubscribe from a public calendar
     return !!calendar && (calendar.isOwner(userId) || calendar.isShared(userId) || calendar.isSubscription());
+  }
+
+  function canMoveEvent(calendar, userId) {
+    return calendar.isOwner(userId);
   }
 
   function canShowDelegationTab(calendar, userId) {

--- a/src/esn.calendar.libs/app/services/cal-ui-authorization-service.spec.js
+++ b/src/esn.calendar.libs/app/services/cal-ui-authorization-service.spec.js
@@ -517,6 +517,30 @@ describe('The calUIAuthorizationService service', function() {
     });
   });
 
+  describe('the canMoveEvent function', function() {
+    var calendar, userId = 'userId';
+
+    it('should return false if user is not the owner of the calendar', function() {
+      calendar = {
+        isOwner: sinon.stub().returns(false)
+      };
+      const result = calUIAuthorizationService.canMoveEvent(calendar, userId);
+
+      expect(calendar.isOwner).to.have.been.calledWith(userId);
+      expect(result).to.be.false;
+    });
+
+    it('should return true if user is the owner of the calendar', function() {
+      calendar = {
+        isOwner: sinon.stub().returns(true)
+      };
+      const result = calUIAuthorizationService.canMoveEvent(calendar, userId);
+
+      expect(calendar.isOwner).to.have.been.calledWith(userId);
+      expect(result).to.be.true;
+    });
+  });
+
   describe('the canShowDelegationTab function', function() {
     var calendar;
 


### PR DESCRIPTION
Introduce a canMoveEvent UI authorization to handle specific authorization that don't match canModifyEvent

For now only calendar owner can move an event.

