### PR TITLE
Fix calendar display in read only calendar

### DIFF
--- a/src/esn.calendar.libs/app/components/event/form/event-form.controller.js
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.controller.js
@@ -180,7 +180,7 @@ function CalEventFormController(
           }
 
           if (calUIAuthorizationService
-            .canMoveEvent(_getCalendarByUniqueId($scope.editedEvent.calendarUniqueId), session.user._id)) {
+            .canMoveEvent(_getCalendarByUniqueId($scope.editedEvent.calendarUniqueId), $scope.editedEvent, session.user)) {
             $scope.calendars = calendars.filter(calendar => calendar.isOwner(session.user._id));
           }
 
@@ -212,7 +212,7 @@ function CalEventFormController(
           return $q.all([
             _canModifyEvent(),
             calUIAuthorizationService.canModifyEventRecurrence(selectedCalendar, $scope.editedEvent, session.user._id),
-            calUIAuthorizationService.canMoveEvent(selectedCalendar, session.user._id)
+            calUIAuthorizationService.canMoveEvent(selectedCalendar, $scope.editedEvent, session.user)
           ]);
         }).then(function([canModifyEventAuthorization, canModifyEventRecurrenceAuthorization, canMoveEventAuthorization]) {
           $scope.canModifyEvent = canModifyEventAuthorization;

--- a/src/esn.calendar.libs/app/components/event/form/event-form.pug
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.pug
@@ -46,8 +46,8 @@ form.event-form(role="form", name="form", aria-hidden="true", ng-class="{ 'reado
                     i.mdi.mdi-calendar-multiple
                   .fg-line
                     md-input-container(ng-click="changeBackdropZIndex()")
-                      md-select(ng-disabled="!canMoveEvent", ng-model="selectedCalendar.uniqueId", md-container-class="cal-select-dropdown" aria-label="calendar")
-                        md-option(ng-value="calendar.getUniqueId()" ng-repeat="calendar in calendars | filter: canMoveEvent ? { readOnly: false } : {}")
+                      md-select(ng-disabled="!canChangeEventCalendar", ng-model="selectedCalendar.uniqueId", md-container-class="cal-select-dropdown" aria-label="calendar")
+                        md-option(ng-value="calendar.getUniqueId()" ng-repeat="calendar in calendars | filter: canChangeEventCalendar ? { readOnly: false } : {}")
                           cal-select-calendar-item(calendar="calendar")
             cal-event-date-edition(event="editedEvent", disabled='!canModifyEvent', use-24hour-format='use24hourFormat', on-date-change='onDateChange')
             cal-entities-autocomplete-input.cal-user-autocomplete-input(

--- a/src/esn.calendar.libs/app/components/event/form/event-form.pug
+++ b/src/esn.calendar.libs/app/components/event/form/event-form.pug
@@ -47,7 +47,7 @@ form.event-form(role="form", name="form", aria-hidden="true", ng-class="{ 'reado
                   .fg-line
                     md-input-container(ng-click="changeBackdropZIndex()")
                       md-select(ng-disabled="!canMoveEvent", ng-model="selectedCalendar.uniqueId", md-container-class="cal-select-dropdown" aria-label="calendar")
-                        md-option(ng-value="calendar.getUniqueId()" ng-repeat="calendar in calendars | filter: { readOnly: false }")
+                        md-option(ng-value="calendar.getUniqueId()" ng-repeat="calendar in calendars | filter: canMoveEvent ? { readOnly: false } : {}")
                           cal-select-calendar-item(calendar="calendar")
             cal-event-date-edition(event="editedEvent", disabled='!canModifyEvent', use-24hour-format='use24hourFormat', on-date-change='onDateChange')
             cal-entities-autocomplete-input.cal-user-autocomplete-input(

--- a/src/esn.calendar.libs/app/services/cal-ui-authorization-service.js
+++ b/src/esn.calendar.libs/app/services/cal-ui-authorization-service.js
@@ -71,8 +71,8 @@ function calUIAuthorizationService(
     return !!calendar && (calendar.isOwner(userId) || calendar.isShared(userId) || calendar.isSubscription());
   }
 
-  function canMoveEvent(calendar, userId) {
-    return calendar.isOwner(userId);
+  function canMoveEvent(calendar, event, user) {
+    return calendar.isOwner(user._id) && calEventUtils.isOrganizer(event, user);
   }
 
   function canShowDelegationTab(calendar, userId) {

--- a/src/esn.calendar.libs/app/services/cal-ui-authorization-service.js
+++ b/src/esn.calendar.libs/app/services/cal-ui-authorization-service.js
@@ -22,7 +22,7 @@ function calUIAuthorizationService(
     canModifyEvent,
     canModifyEventRecurrence,
     canModifyPublicSelection,
-    canMoveEvent,
+    canChangeEventCalendar,
     canShowDelegationTab
   };
 
@@ -71,7 +71,7 @@ function calUIAuthorizationService(
     return !!calendar && (calendar.isOwner(userId) || calendar.isShared(userId) || calendar.isSubscription());
   }
 
-  function canMoveEvent(calendar, event, user) {
+  function canChangeEventCalendar(calendar, event, user) {
     return calendar.isOwner(user._id) && calEventUtils.isOrganizer(event, user);
   }
 

--- a/src/esn.calendar.libs/app/services/cal-ui-authorization-service.spec.js
+++ b/src/esn.calendar.libs/app/services/cal-ui-authorization-service.spec.js
@@ -518,15 +518,27 @@ describe('The calUIAuthorizationService service', function() {
   });
 
   describe('the canMoveEvent function', function() {
-    var calendar, userId = 'userId';
+    var calendar, event = 'event', user = { _id: 'userId' };
 
     it('should return false if user is not the owner of the calendar', function() {
       calendar = {
         isOwner: sinon.stub().returns(false)
       };
-      const result = calUIAuthorizationService.canMoveEvent(calendar, userId);
+      const result = calUIAuthorizationService.canMoveEvent(calendar, event, user);
 
-      expect(calendar.isOwner).to.have.been.calledWith(userId);
+      expect(calendar.isOwner).to.have.been.calledWith(user._id);
+      expect(calEventUtils.isOrganizer).to.not.have.been.called;
+      expect(result).to.be.false;
+    });
+
+    it('should return false if user is the owner of the calendar but user is not event organizer', function() {
+      calendar = {
+        isOwner: sinon.stub().returns(true)
+      };
+      const result = calUIAuthorizationService.canMoveEvent(calendar, event, user);
+
+      expect(calendar.isOwner).to.have.been.calledWith(user._id);
+      expect(calEventUtils.isOrganizer).to.have.been.calledWith(event, user);
       expect(result).to.be.false;
     });
 
@@ -534,9 +546,11 @@ describe('The calUIAuthorizationService service', function() {
       calendar = {
         isOwner: sinon.stub().returns(true)
       };
-      const result = calUIAuthorizationService.canMoveEvent(calendar, userId);
+      calEventUtils.isOrganizer = sinon.stub().returns(true);
+      const result = calUIAuthorizationService.canMoveEvent(calendar, event, user);
 
-      expect(calendar.isOwner).to.have.been.calledWith(userId);
+      expect(calendar.isOwner).to.have.been.calledWith(user._id);
+      expect(calEventUtils.isOrganizer).to.have.been.calledWith(event, user);
       expect(result).to.be.true;
     });
   });

--- a/src/esn.calendar.libs/app/services/cal-ui-authorization-service.spec.js
+++ b/src/esn.calendar.libs/app/services/cal-ui-authorization-service.spec.js
@@ -524,7 +524,7 @@ describe('The calUIAuthorizationService service', function() {
       calendar = {
         isOwner: sinon.stub().returns(false)
       };
-      const result = calUIAuthorizationService.canMoveEvent(calendar, event, user);
+      const result = calUIAuthorizationService.canChangeEventCalendar(calendar, event, user);
 
       expect(calendar.isOwner).to.have.been.calledWith(user._id);
       expect(calEventUtils.isOrganizer).to.not.have.been.called;
@@ -535,7 +535,7 @@ describe('The calUIAuthorizationService service', function() {
       calendar = {
         isOwner: sinon.stub().returns(true)
       };
-      const result = calUIAuthorizationService.canMoveEvent(calendar, event, user);
+      const result = calUIAuthorizationService.canChangeEventCalendar(calendar, event, user);
 
       expect(calendar.isOwner).to.have.been.calledWith(user._id);
       expect(calEventUtils.isOrganizer).to.have.been.calledWith(event, user);
@@ -547,7 +547,7 @@ describe('The calUIAuthorizationService service', function() {
         isOwner: sinon.stub().returns(true)
       };
       calEventUtils.isOrganizer = sinon.stub().returns(true);
-      const result = calUIAuthorizationService.canMoveEvent(calendar, event, user);
+      const result = calUIAuthorizationService.canChangeEventCalendar(calendar, event, user);
 
       expect(calendar.isOwner).to.have.been.calledWith(user._id);
       expect(calEventUtils.isOrganizer).to.have.been.calledWith(event, user);


### PR DESCRIPTION
Fix 2 issues

* If event cannot be modified, calendar select is still active.
* When calendar is shared in read only, event calendar is not properly displayed

